### PR TITLE
Added support for Xcode 7.0.1

### DIFF
--- a/NCSimulatorPlugin/NCSimulatorPlugin-Info.plist
+++ b/NCSimulatorPlugin/NCSimulatorPlugin-Info.plist
@@ -36,6 +36,7 @@
 		<string>9F75337B-21B4-4ADC-B558-F9CADF7073A7</string>
 		<string>E969541F-E6F9-4D25-8158-72DC3545A6C6</string>
 		<string>7FDF5C7A-131F-4ABB-9EDC-8C5F8F0B8A90</string>
+		<string>0420B86A-AA43-4792-9ED0-6FE0F2B16A13</string>
 	</array>
 	<key>NSPrincipalClass</key>
 	<string>NCSimulatorPlugin</string>


### PR DESCRIPTION
Plugin will be silently ignored (and not show up) in Xcode Version 7.0.1 (7A1001) without this. 